### PR TITLE
feat: add PayTrail payment provider

### DIFF
--- a/Core/Ekom.Payments.Core.csproj
+++ b/Core/Ekom.Payments.Core.csproj
@@ -101,6 +101,9 @@
             <_Parameter1>Ekom.Payments.AltaPay</_Parameter1>
         </AssemblyAttribute>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Ekom.Payments.PayTrail</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>Ekom.Payments.ValitorPay</_Parameter1>
         </AssemblyAttribute>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/Ekom.Payments.sln
+++ b/Ekom.Payments.sln
@@ -35,6 +35,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ekom.Payments.AltaPay", "Pa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ekom.Payments.SiminnPay", "PaymentProviders\Ekom.Payments.SiminnPay\Ekom.Payments.SiminnPay.csproj", "{D43487E1-1090-CA6D-4C3E-FD775E0C5448}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ekom.Payments.PayTrail", "PaymentProviders\Ekom.Payments.PayTrail\Ekom.Payments.PayTrail.csproj", "{83760B61-F21E-4018-9306-9C50FC45D6B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +83,10 @@ Global
 		{D43487E1-1090-CA6D-4C3E-FD775E0C5448}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D43487E1-1090-CA6D-4C3E-FD775E0C5448}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D43487E1-1090-CA6D-4C3E-FD775E0C5448}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83760B61-F21E-4018-9306-9C50FC45D6B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83760B61-F21E-4018-9306-9C50FC45D6B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83760B61-F21E-4018-9306-9C50FC45D6B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83760B61-F21E-4018-9306-9C50FC45D6B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +100,7 @@ Global
 		{B2835696-DC8B-BB97-2E55-D9419344280E} = {2B11B5CF-D02F-4E45-8528-801F3F587010}
 		{E9D8085B-8424-A05F-810E-53257C18E345} = {2B11B5CF-D02F-4E45-8528-801F3F587010}
 		{D43487E1-1090-CA6D-4C3E-FD775E0C5448} = {2B11B5CF-D02F-4E45-8528-801F3F587010}
+		{83760B61-F21E-4018-9306-9C50FC45D6B4} = {2B11B5CF-D02F-4E45-8528-801F3F587010}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {39690F49-F3CA-44D3-8831-7E12F4C490BB}

--- a/PaymentProviders/Ekom.Payments.PayTrail/Ekom.Payments.PayTrail.csproj
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Ekom.Payments.PayTrail.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <!-- Package properties -->
+        <PackageId>Ekom.Payments.PayTrail</PackageId>
+        <Version>0.0.1</Version>
+        <Title>Ekom Payments PayTrail</Title>
+        <Authors>Vettvangur</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/Vettvangur/Ekom.Payments</PackageProjectUrl>
+        <PackageIcon>images\VV_Logo.png</PackageIcon>
+        <Description>Ekom Payments PayTrail - Vettvangur E-Commerce solution</Description>
+        <PackageReleaseNotes></PackageReleaseNotes>
+        <Copyright>Copyright 2026</Copyright>
+        <PackageTags></PackageTags>
+
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <Optimize>False</Optimize>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <Optimize>False</Optimize>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\VV_Logo.png" Pack="true" PackagePath="images\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Core\Ekom.Payments.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/PaymentProviders/Ekom.Payments.PayTrail/Events.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Events.cs
@@ -1,0 +1,36 @@
+namespace Ekom.Payments.PayTrail;
+
+/// <summary>
+/// Callbacks to run only for this provider on success/error.
+/// Supplied by library consumer.
+/// </summary>
+public static class Events
+{
+    /// <summary>
+    /// Raises the success event on successful payment verification
+    /// </summary>
+    internal static async Task OnSuccessAsync(object sender, SuccessEventArgs successEventArgs)
+    {
+        Success?.Invoke(sender, successEventArgs);
+        await global::Ekom.Payments.Events.OnSuccessAsync(sender, successEventArgs);
+    }
+
+    /// <summary>
+    /// Raises the error event on failed payments
+    /// </summary>
+    internal static async Task OnErrorAsync(object sender, ErrorEventArgs errorEventArgs)
+    {
+        Error?.Invoke(sender, errorEventArgs);
+        await global::Ekom.Payments.Events.OnErrorAsync(sender, errorEventArgs);
+    }
+
+    /// <summary>
+    /// Event fired on successful payment verification
+    /// </summary>
+    public static event EventHandler<SuccessEventArgs>? Success;
+
+    /// <summary>
+    /// Event fired on payment verification error
+    /// </summary>
+    public static event EventHandler<ErrorEventArgs>? Error;
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentRequest.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentRequest.cs
@@ -1,0 +1,80 @@
+using System.Text.Json.Serialization;
+
+namespace Ekom.Payments.PayTrail.Models;
+
+public class CreatePaymentRequest
+{
+    [JsonPropertyName("stamp")]
+    public string Stamp { get; set; } = string.Empty;
+
+    [JsonPropertyName("reference")]
+    public string Reference { get; set; } = string.Empty;
+
+    [JsonPropertyName("amount")]
+    public int Amount { get; set; }
+
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = string.Empty;
+
+    [JsonPropertyName("language")]
+    public string Language { get; set; } = string.Empty;
+
+    [JsonPropertyName("items")]
+    public IEnumerable<PaymentItem> Items { get; set; } = [];
+
+    [JsonPropertyName("customer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PaymentCustomer? Customer { get; set; }
+
+    [JsonPropertyName("redirectUrls")]
+    public PaymentUrls RedirectUrls { get; set; } = new();
+
+    [JsonPropertyName("callbackUrls")]
+    public PaymentUrls CallbackUrls { get; set; } = new();
+}
+
+public class PaymentItem
+{
+    [JsonPropertyName("unitPrice")]
+    public int UnitPrice { get; set; }
+
+    [JsonPropertyName("units")]
+    public int Units { get; set; }
+
+    [JsonPropertyName("vatPercentage")]
+    public decimal VatPercentage { get; set; }
+
+    [JsonPropertyName("productCode")]
+    public string ProductCode { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+}
+
+public class PaymentCustomer
+{
+    [JsonPropertyName("email")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("firstName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FirstName { get; set; }
+
+    [JsonPropertyName("lastName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LastName { get; set; }
+
+    [JsonPropertyName("phone")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Phone { get; set; }
+}
+
+public class PaymentUrls
+{
+    [JsonPropertyName("success")]
+    public string Success { get; set; } = string.Empty;
+
+    [JsonPropertyName("cancel")]
+    public string Cancel { get; set; } = string.Empty;
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentResponse.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Ekom.Payments.PayTrail.Models;
+
+public class CreatePaymentResponse
+{
+    [JsonPropertyName("transactionId")]
+    public string TransactionId { get; set; } = string.Empty;
+
+    [JsonPropertyName("href")]
+    public Uri? Href { get; set; }
+
+    [JsonPropertyName("reference")]
+    public string Reference { get; set; } = string.Empty;
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/Models/PayTrailCallback.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Models/PayTrailCallback.cs
@@ -1,0 +1,22 @@
+namespace Ekom.Payments.PayTrail.Models;
+
+public class PayTrailCallback
+{
+    public string Account { get; set; } = string.Empty;
+
+    public string Algorithm { get; set; } = string.Empty;
+
+    public int Amount { get; set; }
+
+    public string Stamp { get; set; } = string.Empty;
+
+    public string Reference { get; set; } = string.Empty;
+
+    public string TransactionId { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    public string Provider { get; set; } = string.Empty;
+
+    public string Signature { get; set; } = string.Empty;
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/Models/PayTrailPaymentData.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Models/PayTrailPaymentData.cs
@@ -1,0 +1,12 @@
+namespace Ekom.Payments.PayTrail.Models;
+
+public class PayTrailPaymentData
+{
+    public string TransactionId { get; set; } = string.Empty;
+
+    public string Provider { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    public Dictionary<string, string> Parameters { get; set; } = new();
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailHmacHelper.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailHmacHelper.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Ekom.Payments.PayTrail;
+
+public static class PayTrailHmacHelper
+{
+    public static IDictionary<string, string> CreateHeaders(PayTrailSettings settings, string method)
+    {
+        var headers = new Dictionary<string, string>
+        {
+            ["checkout-account"] = settings.AccountId,
+            ["checkout-algorithm"] = settings.Algorithm,
+            ["checkout-method"] = method,
+            ["checkout-nonce"] = Guid.NewGuid().ToString(),
+            ["checkout-timestamp"] = DateTime.UtcNow.ToString("O"),
+        };
+
+        if (!string.IsNullOrWhiteSpace(settings.PlatformName))
+        {
+            headers["platform-name"] = settings.PlatformName;
+        }
+
+        return headers;
+    }
+
+    public static string CalculateHmac(string secret, IEnumerable<KeyValuePair<string, string>> parameters, string body = "", string algorithm = "sha256")
+    {
+        var payload = string.Join(
+            "\n",
+            parameters
+                .Where(x => x.Key.StartsWith("checkout-", StringComparison.InvariantCultureIgnoreCase))
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .Select(x => $"{x.Key.ToLowerInvariant()}:{x.Value}")
+                .Concat([body]));
+
+        var secretBytes = Encoding.UTF8.GetBytes(secret);
+        var payloadBytes = Encoding.UTF8.GetBytes(payload);
+
+        if (algorithm.Equals("sha512", StringComparison.InvariantCultureIgnoreCase))
+        {
+            using var hmac = new HMACSHA512(secretBytes);
+            return Convert.ToHexString(hmac.ComputeHash(payloadBytes)).ToLowerInvariant();
+        }
+
+        using var hmacSha256 = new HMACSHA256(secretBytes);
+        return Convert.ToHexString(hmacSha256.ComputeHash(payloadBytes)).ToLowerInvariant();
+    }
+
+    public static bool IsValidSignature(string secret, IEnumerable<KeyValuePair<string, string>> parameters, string signature, string body = "")
+    {
+        var algorithm = parameters.FirstOrDefault(x => x.Key.Equals("checkout-algorithm", StringComparison.InvariantCultureIgnoreCase)).Value ?? "sha256";
+        var hmac = CalculateHmac(secret, parameters, body, algorithm);
+
+        return hmac.Equals(signature, StringComparison.InvariantCultureIgnoreCase);
+    }
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailResponseController.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailResponseController.cs
@@ -1,0 +1,209 @@
+using Ekom.Payments.PayTrail.Models;
+using LinqToDB;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Net.Mail;
+
+namespace Ekom.Payments.PayTrail;
+
+/// <summary>
+/// Receives a callback from PayTrail when customer completes payment.
+/// </summary>
+[Route("ekom/payments/[controller]")]
+[ApiController]
+public class PayTrailResponseController : ControllerBase
+{
+    readonly ILogger _logger;
+    readonly PaymentsConfiguration _settings;
+    readonly IOrderService _orderService;
+    readonly IDatabaseFactory _dbFac;
+    readonly IMailService _mailSvc;
+
+    public PayTrailResponseController(
+        ILogger<PayTrailResponseController> logger,
+        PaymentsConfiguration settings,
+        IOrderService orderService,
+        IDatabaseFactory dbFac,
+        IMailService mailSvc)
+    {
+        _logger = logger;
+        _settings = settings;
+        _orderService = orderService;
+        _dbFac = dbFac;
+        _mailSvc = mailSvc;
+    }
+
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpGet, HttpPost]
+    [Route("")]
+    public async Task<IActionResult> Post()
+    {
+        var parameters = Request.Query.ToDictionary(x => x.Key, x => x.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+        var isCallback = parameters.ContainsKey("callback");
+
+        _logger.LogInformation("PayTrail Payment Response - Start");
+        _logger.LogDebug(JsonConvert.SerializeObject(parameters));
+
+        try
+        {
+            var callback = CreateCallback(parameters);
+            if (callback == null || !Guid.TryParse(callback.Stamp, out var orderId))
+            {
+                return BadRequest();
+            }
+
+            var order = await _orderService.GetAsync(orderId).ConfigureAwait(false);
+            if (order == null)
+            {
+                _logger.LogWarning("PayTrail Payment Response - Unable to find order {OrderId}", orderId);
+                return NotFound();
+            }
+
+            var paymentSettings = JsonConvert.DeserializeObject<PaymentSettings>(order.EkomPaymentSettingsData);
+            var payTrailSettings = JsonConvert.DeserializeObject<PayTrailSettings>(order.EkomPaymentProviderData ?? string.Empty);
+
+            if (paymentSettings == null || payTrailSettings == null)
+            {
+                return BadRequest();
+            }
+
+            if (!PayTrailHmacHelper.IsValidSignature(payTrailSettings.SecretKey, parameters, callback.Signature))
+            {
+                _logger.LogWarning("PayTrail Payment Response - Signature mismatch for order {OrderId}", orderId);
+                await Events.OnErrorAsync(this, new ErrorEventArgs
+                {
+                    OrderStatus = order,
+                });
+                return Unauthorized();
+            }
+
+            if (callback.Status.Equals("ok", StringComparison.InvariantCultureIgnoreCase))
+            {
+                var expectedAmount = Payment.ToMinorUnits(order.Amount, paymentSettings.Currency);
+                if (callback.Amount != expectedAmount)
+                {
+                    _logger.LogWarning("PayTrail Payment Response - Amount mismatch for order {OrderId}. Expected {ExpectedAmount}, got {ActualAmount}", orderId, expectedAmount, callback.Amount);
+                    await Events.OnErrorAsync(this, new ErrorEventArgs
+                    {
+                        OrderStatus = order,
+                    });
+                    return BadRequest();
+                }
+
+                if (!order.Paid)
+                {
+                    await SavePaymentDataAsync(order, callback, parameters).ConfigureAwait(false);
+
+                    order.Paid = true;
+                    await _orderService.UpdateAsync(order).ConfigureAwait(false);
+
+                    await Events.OnSuccessAsync(this, new SuccessEventArgs
+                    {
+                        OrderStatus = order,
+                    });
+
+                    _logger.LogInformation("PayTrail Payment Response - SUCCESS - Order ID: {OrderId}", order.UniqueId);
+                }
+                else
+                {
+                    _logger.LogInformation("PayTrail Payment Response - SUCCESS - Previously validated - Order ID: {OrderId}", order.UniqueId);
+                }
+
+                if (isCallback)
+                {
+                    return Ok();
+                }
+
+                var successUrl = Ekom.Payments.Helpers.PaymentsUriHelper.EnsureFullUri(paymentSettings.SuccessUrl.ToString(), Request);
+                return Redirect(successUrl.ToString());
+            }
+
+            await Events.OnErrorAsync(this, new ErrorEventArgs
+            {
+                OrderStatus = order,
+            });
+
+            if (isCallback)
+            {
+                return Ok();
+            }
+
+            var cancelUrl = Ekom.Payments.Helpers.PaymentsUriHelper.EnsureFullUri(paymentSettings.CancelUrl.ToString(), Request);
+            return Redirect(cancelUrl.ToString());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "PayTrail Payment Response - Failed");
+            await Events.OnErrorAsync(this, new ErrorEventArgs
+            {
+                Exception = ex,
+            });
+
+            if (_settings.SendEmailAlerts)
+            {
+                await _mailSvc.SendAsync(new MailMessage
+                {
+                    Subject = "PayTrail Payment Response - Failed",
+                    Body = $"<p>PayTrail Payment Response - Failed<p><br />{HttpContext.Request.GetDisplayUrl()}<br />" + ex + "<br><br> " + JsonConvert.SerializeObject(parameters),
+                    IsBodyHtml = true,
+                });
+            }
+
+            throw;
+        }
+    }
+
+    static PayTrailCallback? CreateCallback(IReadOnlyDictionary<string, string> parameters)
+    {
+        if (!parameters.TryGetValue("signature", out var signature)
+            || !parameters.TryGetValue("checkout-stamp", out var stamp)
+            || !parameters.TryGetValue("checkout-status", out var status)
+            || !parameters.TryGetValue("checkout-amount", out var amount))
+        {
+            return null;
+        }
+
+        return new PayTrailCallback
+        {
+            Account = parameters.GetValueOrDefault("checkout-account") ?? string.Empty,
+            Algorithm = parameters.GetValueOrDefault("checkout-algorithm") ?? string.Empty,
+            Amount = int.Parse(amount),
+            Stamp = stamp,
+            Reference = parameters.GetValueOrDefault("checkout-reference") ?? string.Empty,
+            TransactionId = parameters.GetValueOrDefault("checkout-transaction-id") ?? string.Empty,
+            Status = status,
+            Provider = parameters.GetValueOrDefault("checkout-provider") ?? string.Empty,
+            Signature = signature,
+        };
+    }
+
+    async Task SavePaymentDataAsync(OrderStatus order, PayTrailCallback callback, Dictionary<string, string> parameters)
+    {
+        try
+        {
+            var paymentData = new PaymentData
+            {
+                Id = order.UniqueId,
+                Date = DateTime.Now,
+                PaymentMethod = callback.Provider,
+                CustomData = JsonConvert.SerializeObject(new PayTrailPaymentData
+                {
+                    TransactionId = callback.TransactionId,
+                    Provider = callback.Provider,
+                    Status = callback.Status,
+                    Parameters = parameters,
+                }),
+                Amount = order.Amount.ToString(),
+            };
+
+            using var db = _dbFac.GetDatabase();
+            await db.InsertOrReplaceAsync(paymentData).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "PayTrail Payment Response - Error saving payment data");
+        }
+    }
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailService.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailService.cs
@@ -1,0 +1,60 @@
+using Ekom.Payments.PayTrail.Models;
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace Ekom.Payments.PayTrail;
+
+public class PayTrailService
+{
+    static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    readonly IHttpClientFactory _httpClientFactory;
+    readonly ILogger _logger;
+
+    public PayTrailService(IHttpClientFactory httpClientFactory, ILogger logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<CreatePaymentResponse> CreatePaymentAsync(PayTrailSettings settings, CreatePaymentRequest request)
+    {
+        var body = JsonSerializer.Serialize(request, JsonSerializerOptions);
+        var headers = PayTrailHmacHelper.CreateHeaders(settings, HttpMethod.Post.Method);
+        headers["signature"] = PayTrailHmacHelper.CalculateHmac(settings.SecretKey, headers, body, settings.Algorithm);
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(settings.ApiBaseUrl, "/payments"))
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+
+        foreach (var header in headers)
+        {
+            httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        var httpClient = _httpClientFactory.CreateClient();
+        using var response = await httpClient.SendAsync(httpRequest).ConfigureAwait(false);
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("PayTrail create payment failed. Status: {StatusCode} Body: {ResponseBody}", response.StatusCode, responseBody);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var createPaymentResponse = JsonSerializer.Deserialize<CreatePaymentResponse>(responseBody, JsonSerializerOptions);
+
+        if (createPaymentResponse?.Href == null || string.IsNullOrEmpty(createPaymentResponse.TransactionId))
+        {
+            throw new InvalidOperationException("PayTrail create payment response did not contain transaction id and href.");
+        }
+
+        return createPaymentResponse;
+    }
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailSettings.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailSettings.cs
@@ -1,0 +1,17 @@
+namespace Ekom.Payments.PayTrail;
+
+public class PayTrailSettings : PaymentSettingsBase<PayTrailSettings>
+{
+    public string AccountId { get; set; } = string.Empty;
+
+    public string SecretKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Dev/prod https://services.paytrail.com
+    /// </summary>
+    public Uri ApiBaseUrl { get; set; } = new("https://services.paytrail.com");
+
+    public string Algorithm { get; set; } = "sha256";
+
+    public string PlatformName { get; set; } = "ekom-vettvangur";
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
@@ -1,0 +1,179 @@
+using Ekom.Payments.Helpers;
+using Ekom.Payments.PayTrail.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+
+namespace Ekom.Payments.PayTrail;
+
+/// <summary>
+/// Initiate a payment request with PayTrail
+/// </summary>
+public class Payment : IPaymentProvider
+{
+    internal const string _ppNodeName = "payTrail";
+    const string reportPath = "/ekom/payments/paytrailresponse";
+
+    readonly ILogger<Payment> _logger;
+    readonly IUmbracoService _uService;
+    readonly IOrderService _orderService;
+    readonly HttpContext _httpCtx;
+    readonly IHttpClientFactory _httpClientFactory;
+    readonly IConfiguration _config;
+
+    public Payment(
+        ILogger<Payment> logger,
+        PaymentsConfiguration settings,
+        IUmbracoService uService,
+        IOrderService orderService,
+        IHttpContextAccessor httpContext,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration config)
+    {
+        _logger = logger;
+        _uService = uService;
+        _orderService = orderService;
+        _httpCtx = httpContext.HttpContext ?? throw new NotSupportedException("Payment requests require an httpcontext");
+        _httpClientFactory = httpClientFactory;
+        _config = config;
+    }
+
+    public async Task<string> RequestAsync(PaymentSettings paymentSettings)
+    {
+        ArgumentNullException.ThrowIfNull(paymentSettings);
+        ArgumentNullException.ThrowIfNull(paymentSettings.Orders);
+        ArgumentException.ThrowIfNullOrEmpty(paymentSettings.Language);
+
+        try
+        {
+            _logger.LogInformation("PayTrail Payment Request - Start");
+
+            var payTrailSettings = paymentSettings.CustomSettings.ContainsKey(typeof(PayTrailSettings))
+                ? paymentSettings.CustomSettings[typeof(PayTrailSettings)] as PayTrailSettings
+                : new PayTrailSettings();
+            payTrailSettings ??= new PayTrailSettings();
+
+            _uService.PopulatePaymentProviderProperties(
+                paymentSettings,
+                _ppNodeName,
+                payTrailSettings,
+                PayTrailSettings.Properties);
+
+            ArgumentException.ThrowIfNullOrEmpty(payTrailSettings.AccountId);
+            ArgumentException.ThrowIfNullOrEmpty(payTrailSettings.SecretKey);
+            ArgumentNullException.ThrowIfNull(payTrailSettings.ApiBaseUrl);
+
+            var total = paymentSettings.Orders.Sum(x => x.GrandTotal);
+
+            var orderStatus = await _orderService.InsertAsync(
+                total,
+                paymentSettings,
+                payTrailSettings,
+                null,
+                _httpCtx
+            ).ConfigureAwait(false);
+
+            paymentSettings.SuccessUrl = PaymentsUriHelper.EnsureFullUri(paymentSettings.SuccessUrl, _httpCtx.Request);
+            paymentSettings.SuccessUrl = PaymentsUriHelper.AddQueryString(paymentSettings.SuccessUrl, "?reference=" + orderStatus.UniqueId);
+
+            var cancelUrl = PaymentsUriHelper.EnsureFullUri(paymentSettings.CancelUrl, _httpCtx.Request);
+            var reportUrl = paymentSettings.ReportUrl == null
+                ? PaymentsUriHelper.EnsureFullUri(new Uri(reportPath, UriKind.Relative), _httpCtx.Request)
+                : PaymentsUriHelper.EnsureFullUri(paymentSettings.ReportUrl, _httpCtx.Request);
+            var callbackUrl = PaymentsUriHelper.AddQueryString(reportUrl, "?callback=true");
+
+            var createPaymentRequest = new CreatePaymentRequest
+            {
+                Stamp = orderStatus.UniqueId.ToString(),
+                Reference = !string.IsNullOrEmpty(paymentSettings.OrderNumber) ? paymentSettings.OrderNumber : orderStatus.ReferenceId.ToString(CultureInfo.InvariantCulture),
+                Amount = ToMinorUnits(total, paymentSettings.Currency),
+                Currency = paymentSettings.Currency,
+                Language = ParseSupportedLanguage(paymentSettings.Language),
+                Items = paymentSettings.Orders.Select((lineItem, index) => new PaymentItem
+                {
+                    UnitPrice = ToMinorUnits(lineItem.Price, paymentSettings.Currency),
+                    Units = lineItem.Quantity,
+                    VatPercentage = 0,
+                    ProductCode = index.ToString(CultureInfo.InvariantCulture),
+                    Description = lineItem.Title,
+                }).ToList(),
+                Customer = CreateCustomer(paymentSettings.CustomerInfo),
+                RedirectUrls = new PaymentUrls
+                {
+                    Success = reportUrl.ToString(),
+                    Cancel = reportUrl.ToString(),
+                },
+                CallbackUrls = new PaymentUrls
+                {
+                    Success = callbackUrl.ToString(),
+                    Cancel = callbackUrl.ToString(),
+                },
+            };
+
+            var svc = new PayTrailService(_httpClientFactory, _logger);
+            var response = await svc.CreatePaymentAsync(payTrailSettings, createPaymentRequest).ConfigureAwait(false);
+
+            orderStatus.CustomData = response.TransactionId;
+            await _orderService.UpdateAsync(orderStatus).ConfigureAwait(false);
+
+            _logger.LogInformation("PayTrail Payment Request - Amount: {Total} OrderId: {OrderId} TransactionId: {TransactionId}", total, orderStatus.UniqueId, response.TransactionId);
+
+            var cspNonce = CspHelper.GetCspNonce(_httpCtx, _config);
+            return FormHelper.CreateRequest(new Dictionary<string, string?>(), response.Href!.ToString(), "GET", cspNonce: cspNonce);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "PayTrail Payment Request - Payment Request Failed. OrderId: {OrderId} OrderNumber: {OrderNumber}", paymentSettings.OrderUniqueId, paymentSettings.OrderNumber);
+            await Events.OnErrorAsync(this, new ErrorEventArgs
+            {
+                Exception = ex,
+            });
+            throw;
+        }
+    }
+
+    internal static int ToMinorUnits(decimal amount, string currency)
+    {
+        var multiplier = IsZeroDecimalCurrency(currency) ? 1 : 100;
+        return Convert.ToInt32(Math.Round(amount * multiplier, 0, MidpointRounding.AwayFromZero));
+    }
+
+    internal static bool IsZeroDecimalCurrency(string currency)
+    {
+        return currency.Equals("ISK", StringComparison.InvariantCultureIgnoreCase)
+            || currency.Equals("JPY", StringComparison.InvariantCultureIgnoreCase)
+            || currency.Equals("KRW", StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    static PaymentCustomer? CreateCustomer(CustomerInfo customerInfo)
+    {
+        if (customerInfo == null)
+        {
+            return null;
+        }
+
+        var names = (customerInfo.Name ?? string.Empty).Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+        return new PaymentCustomer
+        {
+            Email = customerInfo.Email,
+            FirstName = names.FirstOrDefault(),
+            LastName = names.Length > 1 ? names[1] : null,
+            Phone = customerInfo.PhoneNumber,
+        };
+    }
+
+    static string ParseSupportedLanguage(string language)
+    {
+        var parsed = CultureInfo.GetCultureInfo(language).TwoLetterISOLanguageName.ToUpperInvariant();
+
+        return parsed switch
+        {
+            "FI" => "FI",
+            "SV" => "SV",
+            "EN" => "EN",
+            _ => "EN",
+        };
+    }
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/PaymentSettingsExtensions.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PaymentSettingsExtensions.cs
@@ -1,0 +1,11 @@
+namespace Ekom.Payments.PayTrail;
+
+public static class PaymentSettingsExtensions
+{
+    public static void SetPayTrailSettings(
+        this PaymentSettings settings,
+        PayTrailSettings payTrailSettings)
+    {
+        settings.CustomSettings[typeof(PayTrailSettings)] = payTrailSettings;
+    }
+}

--- a/PaymentProviders/Ekom.Payments.PayTrail/README.md
+++ b/PaymentProviders/Ekom.Payments.PayTrail/README.md
@@ -1,0 +1,158 @@
+# Ekom.Payments.PayTrail
+
+PayTrail payment provider for Ekom Payments. This provider implements the PayTrail hosted payment flow for normal payments.
+
+PayTrail documentation: <https://docs.paytrail.com/#/>
+
+## Supported features
+
+- Creates payments through PayTrail `POST /payments`.
+- Redirects customers to the PayTrail hosted payment page.
+- Validates PayTrail signed return and callback parameters.
+- Marks Ekom payment orders as paid when PayTrail returns `checkout-status=ok`.
+- Stores the PayTrail transaction ID in the Ekom payment order `CustomData` field.
+- Stores payment callback data in `EkomPayments`.
+
+Not currently implemented:
+
+- Refunds
+- Token payments
+- Payment method button rendering
+- Payment reports
+
+## Provider alias
+
+The payment provider node alias/name used by this provider is:
+
+```text
+payTrail
+```
+
+Use this name for the Umbraco payment provider node, or pass PayTrail settings directly through `PaymentSettings.CustomSettings`.
+
+## Settings
+
+Configure these values on the PayTrail payment provider node or set them in code with `SetPayTrailSettings`.
+
+| Setting | Required | Default | Description |
+| --- | --- | --- | --- |
+| `AccountId` | Yes | | PayTrail merchant account ID. |
+| `SecretKey` | Yes | | PayTrail merchant secret key used for HMAC signing. |
+| `ApiBaseUrl` | Yes | `https://services.paytrail.com` | PayTrail API base URL. |
+| `Algorithm` | Yes | `sha256` | HMAC algorithm. PayTrail supports `sha256` and `sha512`. |
+| `PlatformName` | No | `ekom-vettvangur` | Sent as PayTrail `platform-name` header. |
+
+PayTrail test credentials from their documentation:
+
+```text
+AccountId: 375917
+SecretKey: SAIPPUAKAUPPIAS
+```
+
+## Code configuration example
+
+```csharp
+using Ekom.Payments.PayTrail;
+
+paymentSettings.SetPayTrailSettings(new PayTrailSettings
+{
+    AccountId = "375917",
+    SecretKey = "SAIPPUAKAUPPIAS",
+    ApiBaseUrl = new Uri("https://services.paytrail.com"),
+    Algorithm = "sha256",
+    PlatformName = "ekom-vettvangur",
+});
+```
+
+## Payment flow
+
+1. `Payment.RequestAsync` validates the incoming `PaymentSettings`.
+2. Provider settings are populated from Umbraco/config/custom settings.
+3. A pending Ekom payment order is inserted.
+4. A PayTrail create-payment payload is built from the Ekom order data.
+5. The provider signs the request with PayTrail HMAC headers.
+6. PayTrail returns a `transactionId` and hosted payment `href`.
+7. The `transactionId` is saved to the Ekom payment order `CustomData` field.
+8. The customer is redirected to the PayTrail hosted payment page.
+9. PayTrail redirects the customer back to `/ekom/payments/paytrailresponse`.
+10. PayTrail also calls the same response endpoint with `callback=true` for server callbacks.
+11. The response controller validates the PayTrail signature and amount.
+12. If `checkout-status=ok`, the Ekom order is marked paid and success events are raised.
+
+## URLs
+
+The default PayTrail response endpoint is:
+
+```text
+/ekom/payments/paytrailresponse
+```
+
+The provider sends this endpoint to PayTrail as both success and cancel redirect URL. The response controller then redirects the customer to the configured Ekom `SuccessUrl` or `CancelUrl` after validation.
+
+Server callbacks are sent to the same endpoint with `callback=true`. Callback requests return `200 OK` after processing instead of redirecting.
+
+## Amounts and currencies
+
+PayTrail expects amounts in the currency minor unit.
+
+The provider converts Ekom decimal amounts as follows:
+
+- Most currencies: multiplied by `100`.
+- Zero-decimal currencies (`ISK`, `JPY`, `KRW`): no multiplier.
+
+Line items are sent with `vatPercentage = 0` because Ekom `OrderItem` does not currently expose VAT percentage data.
+
+## Language mapping
+
+PayTrail supports `FI`, `SV`, and `EN`.
+
+The provider maps the Ekom culture to PayTrail language codes:
+
+- Finnish cultures -> `FI`
+- Swedish cultures -> `SV`
+- English cultures -> `EN`
+- Any other language -> `EN`
+
+## Response validation
+
+The response controller validates every PayTrail return/callback by:
+
+- Filtering query parameters to `checkout-*` keys.
+- Sorting keys alphabetically.
+- Calculating an HMAC with the configured `SecretKey`.
+- Comparing the calculated HMAC to the `signature` parameter.
+- Checking that `checkout-amount` matches the stored Ekom order amount.
+
+Only a valid `checkout-status=ok` response marks the order as paid.
+
+## Events
+
+Provider-specific events are exposed through `Ekom.Payments.PayTrail.Events`:
+
+```csharp
+Events.Success += (sender, args) =>
+{
+    // Payment verified successfully.
+};
+
+Events.Error += (sender, args) =>
+{
+    // Payment failed or verification failed.
+};
+```
+
+These events also forward to the global Ekom payment events.
+
+## Build
+
+From the repository root:
+
+```bash
+dotnet build Ekom.Payments.sln
+```
+
+## Notes
+
+- Keep PayTrail `SecretKey` out of source control.
+- PayTrail may call callbacks more than once; the response controller is idempotent for already-paid orders.
+- The PayTrail signature payload uses line feed (`\n`) separators. Carriage returns are not supported by PayTrail.

--- a/PaymentProviders/Ekom.Payments.PayTrail/packages.lock.json
+++ b/PaymentProviders/Ekom.Payments.PayTrail/packages.lock.json
@@ -1,0 +1,340 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "aZyGyGg2nFSxix+xMkPmlmZSsnGQ3w+mIG23LTxJZHN+GPwTQ5FpPgDo7RMOq+Kcf5D4hFWfXkGhoGstawX13Q==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.0.0",
+          "Microsoft.SourceLink.Common": "1.0.0"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.51.0",
+        "contentHash": "WzIcQzKPG/iDWYrl0F5YZH78ZYTfjCc2UVZ4HyVX9QxUYiiJmbCCled0NZGCp1XBMhlKC5ilUlU35Bfe68uKiA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.2",
+          "System.ClientModel": "1.9.0",
+          "System.Memory.Data": "10.0.1"
+        }
+      },
+      "Azure.Identity": {
+        "type": "Transitive",
+        "resolved": "1.17.1",
+        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Microsoft.Identity.Client": "4.78.0",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
+        }
+      },
+      "Ekom.Common": {
+        "type": "Transitive",
+        "resolved": "0.2.30",
+        "contentHash": "ItMx07foRMguAduotMlw0OoU8dA/4NZ3hvFI2jozwy6FrtbSO/osQAYUstR3DUV2A2r4Rj/60yWAAvYl8KnvuA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "linq2db": {
+        "type": "Transitive",
+        "resolved": "5.4.1",
+        "contentHash": "qyH32MbFK6T55KsEcQYTbPFfkOa1Mo65lY/Zo8SFVMy0pwkQBCTnA/RUxyG5+l3D/mgfPz85PH3upDrtklSMrw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "qE5JhRoeJbAipLqpUCZyNfNwnpAvUttXgIQDnTiJ15d8ji+/bPgoPkB3xLzK5cQTobN2D2ditUesUlDHb7p3Pg=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "Y3t/c7C5XHJGFDnohjf1/9SYF3ZOfEU1fkNQuKg/dGf9hN18yrQj2owHITGfNS3+lKJdW6J4vY98jYu57jCO8A=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "z2fpmmt+1Jfl+ZnBki9nSP08S1/tbEOxFdsK1rSR+LBehIJz1Xv9/6qOOoGNqlwnAGGVGis1Oj6S8Kt9COEYlQ=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "6.1.2",
+        "contentHash": "q0GxRC0fgwfZgU14pU34ro0MW7Gs8S6NDmKCcEqymvZljT8UQa633BbEmk/Rb5upNF9NHZ3/jVm7zLiWbM8uTA==",
+        "dependencies": {
+          "Azure.Core": "1.47.1",
+          "Azure.Identity": "1.14.2",
+          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.7.1",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Cryptography.Pkcs": "8.0.1",
+          "System.Text.Json": "8.0.5"
+        }
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "KC5PslaTDnTuTvyke0KYAVBYdZ7IVTsU3JhHe69BpEbHLcj1YThP3bIGtZNOkZfast2AuLnul5lk4rZKxAdUGQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "zOIurr59+kUf9vNcsUkCvKWZv+fPosUZXURZesYkJCvl0EzTc9F7maAO4Cd2WEV7ZJJ0AZrFQvuH6Npph9wdBw=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "GaiaeKUuLuUbRPkUokndDuzonhO6dk4lcfGflHsCeXiJ5JrZxcyks1KuG6eB9pON16x/+9uWfa4w9g3oP8AYvQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Options": "10.0.2",
+          "System.Diagnostics.DiagnosticSource": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "+r/eJ+slW/EmwWmH3En4gzRg1k6+yTqexoHBrMuz5fxsIKJA8MDiSGepjw/ko3XyNqg+w3dxQe+huoVXs5XDJw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "CeAAPVOtI/wtBcHOwq6Pw3VPdGi+pNaGHZj6vfXX/5zr8beO9SyL7IOCSQ70BauFTAFS0QF7f6zu2A6hC8D6nw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.2",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "RZkez/JjpnO+MZ6efKkSynN6ZztLpw3WbxNzjLCPBd97wWj1S9ZYPWi0nmT4kWBRa6atHsdM1ydGkUr8GudyDQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2",
+          "System.Diagnostics.DiagnosticSource": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "1De2LJjmxdqopI5AYC5dIhoZQ79AR5ayywxNF1rXrXFtKQfbQOV9+n/IsZBa7qWlr0MqoGpW8+OY2v/57udZOA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Primitives": "10.0.2"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "QmSiO+oLBEooGgB3i0GRXyeYRDHjllqt3k365jwfZlYWhvSHA3UL2NEVV5m8aZa041eIlblo6KMI5txvTMpTwA=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.78.0",
+        "contentHash": "vZ50HE9INSN+Ew8pCgTm0t7wzxQTqozF9L4MAsl64etXz0Teo0dbUvjpVzqDHRs6m1Vn8mHF04fGaxXrIvGpsg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.78.0",
+        "contentHash": "DYU9o+DrDQuyZxeq91GBA9eNqBvA3ZMkLzQpF7L9dTk6FcIBM1y1IHXWqiKXTvptPF7CZE59upbyUoa+FJ5eiA==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.78.0",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "3Izi75UCUssvo8LPx3OVnEeZay58qaFicrtSnbtUt7q8qQi0gy46gh4V8VUTkMVMKXV6VMyjBVmeNNgeCUJuIw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "BZNgSq/o8gsKExdYoBKPR65fdsxW0cTF8PsdqB8y011AGUJJW300S/ZIsEUD0+sOmGc003Gwv3FYbjrVjvsLNQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "h+fHHBGokepmCX+QZXJk4Ij8OApCb2n2ktoDkNX5CXteXsOxTHMNgjPGpAwdJMFvAL7TtGarUnk3o97NmBq2QQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "yT2Hdj8LpPbcT9C9KlLVxXl09C8zjFaVSaApdOwuecMuoV4s6Sof/mnTDz/+F/lILPIBvrWugR9CC7iRVZgbfQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "7.7.1",
+          "System.IdentityModel.Tokens.Jwt": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "fQ0VVCba75lknUHGldi3iTKAYUQqbzp1Un8+d9cm9nON0Gs8NAkXddNg8iaUB0qi/ybtAmNWizTR4avdkCJ9pQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.7.1"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg=="
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "1wdwKtMMMEFEYsxJmtrOd3G+7zVOVO3MlVZAsbKv9H0PnIx6J27fYAarMn0eQS0vKJPQL018DOb7YRK1O97p0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.2",
+          "System.Memory.Data": "10.0.1"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.1",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "lYWBy8fKkJHaRcOuw30d67PrtVjR5754sz5Wl76s8P+vJ9FSThh9b7LIcTSODx1LY7NB3Srvg+JMnzd67qNZOw=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "rQkO1YbAjLwnDJSMpRhRtrc6XwIcEOcUvoEcge+evurpzSZM3UNK+MZfD3sKyTlYsvknZ6eJjSBfnmXqwOsT9Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "BZC4mhdL569AXV56ep9YO6ShjhxFXGP7SwVX0Bc/e0dJPWnS6aBEXZJXqh64RVx8HquqWHkJUINBydLRQ1yq0g==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
+        }
+      },
+      "ekom.payments.core": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Core": "[1.51.0, )",
+          "Azure.Identity": "[1.17.1, )",
+          "Ekom.Common": "[0.2.30, )",
+          "Microsoft.Data.SqlClient": "[6.1.2, )",
+          "linq2db": "[5.4.1, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new PayTrail payment provider project for hosted payment redirects.
- Implement PayTrail HMAC request signing and return/callback validation.
- Document setup, settings, payment flow, and supported limitations in the provider README.

## Test Plan
- dotnet build Ekom.Payments.sln