### PR TITLE
fix(paytrail): allow settings configuration binding

### DIFF
--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailSettings.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailSettings.cs
@@ -2,16 +2,16 @@ namespace Ekom.Payments.PayTrail;
 
 public class PayTrailSettings : PaymentSettingsBase<PayTrailSettings>
 {
-    public string AccountId { get; set; } = string.Empty;
+    public string AccountId { get; set; } = null!;
 
-    public string SecretKey { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = null!;
 
     /// <summary>
     /// Dev/prod https://services.paytrail.com
     /// </summary>
-    public Uri ApiBaseUrl { get; set; } = new("https://services.paytrail.com");
+    public Uri ApiBaseUrl { get; set; } = null!;
 
-    public string Algorithm { get; set; } = "sha256";
+    public string Algorithm { get; set; } = null!;
 
-    public string PlatformName { get; set; } = "ekom-vettvangur";
+    public string PlatformName { get; set; } = null!;
 }


### PR DESCRIPTION
## Summary
- Allow PayTrail settings to be populated from Umbraco/appsettings by leaving values unset before provider property population.
- Fixes empty `AccountId`/`SecretKey` values when using `configurationKey` such as `payTrail`.

## Test Plan
- `dotnet build "PaymentProviders/Ekom.Payments.PayTrail/Ekom.Payments.PayTrail.csproj"`