### PR TITLE
feat: add Teya Consumer Loans payment provider

### DIFF
--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Ekom.Payments.TeyaConsumerloans.csproj
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Ekom.Payments.TeyaConsumerloans.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <PackageId>Ekom.Payments.TeyaConsumerloans</PackageId>
+        <Version>0.0.1</Version>
+        <Title>Ekom Payments Teya Consumer Loans</Title>
+        <Authors>Vettvangur</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/Vettvangur/Ekom.Payments</PackageProjectUrl>
+        <PackageIcon>images\VV_Logo.png</PackageIcon>
+        <Description>Ekom Payments Teya Consumer Loans - Vettvangur E-Commerce solution</Description>
+        <PackageReleaseNotes></PackageReleaseNotes>
+        <Copyright>Copyright 2026</Copyright>
+        <PackageTags></PackageTags>
+
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <Optimize>False</Optimize>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <Optimize>False</Optimize>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\VV_Logo.png" Pack="true" PackagePath="images\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Core\Ekom.Payments.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Events.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Events.cs
@@ -1,0 +1,36 @@
+namespace Ekom.Payments.TeyaConsumerloans;
+
+/// <summary>
+/// Callbacks to run only for this provider on success/error.
+/// Supplied by library consumer.
+/// </summary>
+public static class Events
+{
+    /// <summary>
+    /// Raises the success event on successful loan application creation.
+    /// </summary>
+    internal static async Task OnSuccessAsync(object sender, SuccessEventArgs successEventArgs)
+    {
+        Success?.Invoke(sender, successEventArgs);
+        await global::Ekom.Payments.Events.OnSuccessAsync(sender, successEventArgs);
+    }
+
+    /// <summary>
+    /// Raises the error event on failed loan applications.
+    /// </summary>
+    internal static async Task OnErrorAsync(object sender, ErrorEventArgs errorEventArgs)
+    {
+        Error?.Invoke(sender, errorEventArgs);
+        await global::Ekom.Payments.Events.OnErrorAsync(sender, errorEventArgs);
+    }
+
+    /// <summary>
+    /// Event fired when the loan application is successfully initialized.
+    /// </summary>
+    public static event EventHandler<SuccessEventArgs>? Success;
+
+    /// <summary>
+    /// Event fired on loan application errors.
+    /// </summary>
+    public static event EventHandler<ErrorEventArgs>? Error;
+}

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Models/LoanApplicationRequest.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Models/LoanApplicationRequest.cs
@@ -1,0 +1,95 @@
+using System.Text.Json.Serialization;
+
+namespace Ekom.Payments.TeyaConsumerloans.Models;
+
+public class LoanApplicationRequest
+{
+    [JsonPropertyName("reference")]
+    public string Reference { get; set; } = string.Empty;
+
+    [JsonPropertyName("amount")]
+    public decimal Amount { get; set; }
+
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = string.Empty;
+
+    [JsonPropertyName("language")]
+    public string Language { get; set; } = string.Empty;
+
+    [JsonPropertyName("successUrl")]
+    public string SuccessUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("cancelUrl")]
+    public string CancelUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("merchantId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MerchantId { get; set; }
+
+    [JsonPropertyName("storeId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StoreId { get; set; }
+
+    [JsonPropertyName("productCode")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ProductCode { get; set; }
+
+    [JsonPropertyName("customer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LoanCustomer? Customer { get; set; }
+
+    [JsonPropertyName("items")]
+    public List<LoanApplicationItem> Items { get; set; } = [];
+}
+
+public class LoanCustomer
+{
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("email")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("phoneNumber")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PhoneNumber { get; set; }
+
+    [JsonPropertyName("nationalRegistryId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? NationalRegistryId { get; set; }
+
+    [JsonPropertyName("address")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Address { get; set; }
+
+    [JsonPropertyName("city")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? City { get; set; }
+
+    [JsonPropertyName("postalCode")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PostalCode { get; set; }
+}
+
+public class LoanApplicationItem
+{
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("quantity")]
+    public int Quantity { get; set; }
+
+    [JsonPropertyName("unitPrice")]
+    public decimal UnitPrice { get; set; }
+
+    [JsonPropertyName("amount")]
+    public decimal Amount { get; set; }
+}
+
+public class LoanTokenResponse
+{
+    [JsonPropertyName("token")]
+    public string Token { get; set; } = string.Empty;
+}

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Payment.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/Payment.cs
@@ -1,0 +1,175 @@
+using Ekom.Payments.Helpers;
+using Ekom.Payments.TeyaConsumerloans.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+
+namespace Ekom.Payments.TeyaConsumerloans;
+
+/// <summary>
+/// Initiates a Teya/Borgun Consumer Loans application and redirects the customer to the loan portal.
+/// </summary>
+public class Payment : IPaymentProvider
+{
+    internal const string _ppNodeName = "teyaConsumerloans";
+
+    readonly ILogger<Payment> _logger;
+    readonly IUmbracoService _uService;
+    readonly IOrderService _orderService;
+    readonly HttpContext _httpCtx;
+    readonly IHttpClientFactory _httpClientFactory;
+    readonly IConfiguration _config;
+
+    public Payment(
+        ILogger<Payment> logger,
+        PaymentsConfiguration settings,
+        IUmbracoService uService,
+        IOrderService orderService,
+        IHttpContextAccessor httpContext,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration config)
+    {
+        _logger = logger;
+        _uService = uService;
+        _orderService = orderService;
+        _httpCtx = httpContext.HttpContext ?? throw new NotSupportedException("Payment requests require an httpcontext");
+        _httpClientFactory = httpClientFactory;
+        _config = config;
+    }
+
+    public async Task<string> RequestAsync(PaymentSettings paymentSettings)
+    {
+        ArgumentNullException.ThrowIfNull(paymentSettings);
+        ArgumentNullException.ThrowIfNull(paymentSettings.Orders);
+        ArgumentException.ThrowIfNullOrEmpty(paymentSettings.Language);
+
+        try
+        {
+            _logger.LogInformation("Teya Consumer Loans Payment Request - Start");
+
+            var teyaSettings = paymentSettings.CustomSettings.ContainsKey(typeof(TeyaConsumerloansSettings))
+                ? paymentSettings.CustomSettings[typeof(TeyaConsumerloansSettings)] as TeyaConsumerloansSettings
+                : new TeyaConsumerloansSettings();
+            teyaSettings ??= new TeyaConsumerloansSettings();
+
+            _uService.PopulatePaymentProviderProperties(
+                paymentSettings,
+                _ppNodeName,
+                teyaSettings,
+                TeyaConsumerloansSettings.Properties);
+
+            ArgumentNullException.ThrowIfNull(teyaSettings.ApiBaseUrl);
+            ArgumentNullException.ThrowIfNull(teyaSettings.LoanPortalUrl);
+
+            if (string.IsNullOrWhiteSpace(teyaSettings.Username) && string.IsNullOrWhiteSpace(teyaSettings.ApiKey))
+            {
+                throw new ArgumentException("Either Username/Password or ApiKey must be configured for Teya Consumer Loans.");
+            }
+
+            var total = paymentSettings.Orders.Sum(x => x.GrandTotal);
+
+            var orderStatus = await _orderService.InsertAsync(
+                total,
+                paymentSettings,
+                teyaSettings,
+                paymentSettings.OrderUniqueId.ToString(),
+                _httpCtx
+            ).ConfigureAwait(false);
+
+            paymentSettings.SuccessUrl = PaymentsUriHelper.EnsureFullUri(paymentSettings.SuccessUrl, _httpCtx.Request);
+            paymentSettings.SuccessUrl = PaymentsUriHelper.AddQueryString(paymentSettings.SuccessUrl, "?reference=" + orderStatus.UniqueId);
+
+            var cancelUrl = PaymentsUriHelper.EnsureFullUri(paymentSettings.CancelUrl, _httpCtx.Request);
+
+            var request = new LoanApplicationRequest
+            {
+                Reference = !string.IsNullOrEmpty(paymentSettings.OrderNumber)
+                    ? paymentSettings.OrderNumber
+                    : orderStatus.UniqueId.ToString(),
+                Amount = total,
+                Currency = paymentSettings.Currency,
+                Language = ParseSupportedLanguage(paymentSettings.Language),
+                SuccessUrl = paymentSettings.SuccessUrl.ToString(),
+                CancelUrl = cancelUrl.ToString(),
+                MerchantId = teyaSettings.MerchantId,
+                StoreId = teyaSettings.StoreId,
+                ProductCode = teyaSettings.ProductCode,
+                Customer = CreateCustomer(paymentSettings.CustomerInfo),
+                Items = paymentSettings.Orders.Select(x => new LoanApplicationItem
+                {
+                    Description = x.Title,
+                    Quantity = x.Quantity,
+                    UnitPrice = x.Price,
+                    Amount = x.GrandTotal,
+                }).ToList(),
+            };
+
+            var client = new TeyaConsumerloansClient(_httpClientFactory, _logger);
+            var tokenResponse = await client.CreateWebTokenAsync(teyaSettings, request).ConfigureAwait(false);
+            var redirectUrl = CreateLoanPortalUrl(teyaSettings, tokenResponse.Token);
+
+            orderStatus.CustomData = tokenResponse.Token;
+            await _orderService.UpdateAsync(orderStatus).ConfigureAwait(false);
+
+            _logger.LogInformation("Teya Consumer Loans Payment Request - Amount: {Total} OrderId: {OrderId}", total, orderStatus.UniqueId);
+
+            await Events.OnSuccessAsync(this, new SuccessEventArgs
+            {
+                OrderStatus = orderStatus,
+            }).ConfigureAwait(false);
+
+            var cspNonce = CspHelper.GetCspNonce(_httpCtx, _config);
+            return FormHelper.CreateRequest(new Dictionary<string, string?>(), redirectUrl.ToString(), "GET", cspNonce: cspNonce);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Teya Consumer Loans Payment Request - Payment Request Failed. OrderId: {OrderId} OrderNumber: {OrderNumber}", paymentSettings.OrderUniqueId, paymentSettings.OrderNumber);
+            await Events.OnErrorAsync(this, new ErrorEventArgs
+            {
+                Exception = ex,
+            }).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    static Uri CreateLoanPortalUrl(TeyaConsumerloansSettings settings, string token)
+    {
+        var parameterName = string.IsNullOrWhiteSpace(settings.LoanPortalTokenQueryParameter)
+            ? "token"
+            : settings.LoanPortalTokenQueryParameter;
+
+        var separator = string.IsNullOrEmpty(settings.LoanPortalUrl.Query) ? "?" : "&";
+        return new Uri(settings.LoanPortalUrl + separator + Uri.EscapeDataString(parameterName) + "=" + Uri.EscapeDataString(token));
+    }
+
+    static LoanCustomer? CreateCustomer(CustomerInfo? customerInfo)
+    {
+        if (customerInfo == null)
+        {
+            return null;
+        }
+
+        return new LoanCustomer
+        {
+            Name = customerInfo.Name,
+            Email = customerInfo.Email,
+            PhoneNumber = customerInfo.PhoneNumber,
+            NationalRegistryId = customerInfo.NationalRegistryId,
+            Address = customerInfo.Address,
+            City = customerInfo.City,
+            PostalCode = customerInfo.PostalCode,
+        };
+    }
+
+    static string ParseSupportedLanguage(string language)
+    {
+        var parsed = CultureInfo.GetCultureInfo(language).TwoLetterISOLanguageName.ToUpperInvariant();
+        return parsed switch
+        {
+            "IS" => "is",
+            "EN" => "en",
+            _ => "is",
+        };
+    }
+}

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/PaymentSettingsExtensions.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/PaymentSettingsExtensions.cs
@@ -1,0 +1,11 @@
+namespace Ekom.Payments.TeyaConsumerloans;
+
+public static class PaymentSettingsExtensions
+{
+    public static void SetTeyaConsumerloansSettings(
+        this PaymentSettings settings,
+        TeyaConsumerloansSettings teyaConsumerloansSettings)
+    {
+        settings.CustomSettings[typeof(TeyaConsumerloansSettings)] = teyaConsumerloansSettings;
+    }
+}

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/TeyaConsumerloansClient.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/TeyaConsumerloansClient.cs
@@ -1,0 +1,62 @@
+using Ekom.Payments.TeyaConsumerloans.Models;
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace Ekom.Payments.TeyaConsumerloans;
+
+internal class TeyaConsumerloansClient
+{
+    static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    readonly IHttpClientFactory _httpClientFactory;
+    readonly ILogger _logger;
+
+    public TeyaConsumerloansClient(IHttpClientFactory httpClientFactory, ILogger logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<LoanTokenResponse> CreateWebTokenAsync(TeyaConsumerloansSettings settings, LoanApplicationRequest request)
+    {
+        var httpClient = _httpClientFactory.CreateClient();
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(settings.ApiBaseUrl, "online/token/web"))
+        {
+            Content = JsonContent.Create(request, options: JsonSerializerOptions),
+        };
+
+        if (!string.IsNullOrWhiteSpace(settings.ApiKey))
+        {
+            httpRequest.Headers.TryAddWithoutValidation("X-API-Key", settings.ApiKey);
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Username) || !string.IsNullOrWhiteSpace(settings.Password))
+        {
+            var rawCredentials = $"{settings.Username}:{settings.Password}";
+            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(rawCredentials)));
+        }
+
+        using var response = await httpClient.SendAsync(httpRequest).ConfigureAwait(false);
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Teya Consumer Loans token request failed. Status: {StatusCode} Body: {ResponseBody}", response.StatusCode, responseBody);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var tokenResponse = JsonSerializer.Deserialize<LoanTokenResponse>(responseBody, JsonSerializerOptions);
+        if (tokenResponse == null || string.IsNullOrWhiteSpace(tokenResponse.Token))
+        {
+            throw new InvalidOperationException("Teya Consumer Loans token response did not contain a token.");
+        }
+
+        return tokenResponse;
+    }
+}

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/TeyaConsumerloansSettings.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/TeyaConsumerloansSettings.cs
@@ -1,0 +1,51 @@
+namespace Ekom.Payments.TeyaConsumerloans;
+
+public class TeyaConsumerloansSettings : PaymentSettingsBase<TeyaConsumerloansSettings>
+{
+    /// <summary>
+    /// Base API url for Consumer Loans API v3.
+    /// Example: https://api.borgun.is/consumerloans/v3/
+    /// </summary>
+    public Uri ApiBaseUrl { get; set; } = new("https://api.borgun.is/consumerloans/v3/");
+
+    /// <summary>
+    /// Merchant or partner user name supplied by Teya/Borgun.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Merchant or partner password supplied by Teya/Borgun.
+    /// </summary>
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional API key if the merchant agreement uses an API-key based integration.
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Base URL for the Teya/Borgun self-service loan portal.
+    /// The token returned from /online/token/web is appended as the configured token query parameter.
+    /// </summary>
+    public Uri LoanPortalUrl { get; set; } = new("https://mitt.borgun.is/consumerloans/");
+
+    /// <summary>
+    /// Query-string parameter name used when redirecting customers to the loan portal.
+    /// </summary>
+    public string LoanPortalTokenQueryParameter { get; set; } = "token";
+
+    /// <summary>
+    /// Optional store or merchant identifier expected by the Consumer Loans API.
+    /// </summary>
+    public string? MerchantId { get; set; }
+
+    /// <summary>
+    /// Optional store location identifier expected by the Consumer Loans API.
+    /// </summary>
+    public string? StoreId { get; set; }
+
+    /// <summary>
+    /// Optional campaign or product code for the financing product.
+    /// </summary>
+    public string? ProductCode { get; set; }
+}


### PR DESCRIPTION
## Summary
- Adds a new `Ekom.Payments.TeyaConsumerloans` payment provider project.
- Implements the initial hosted loan application flow by persisting the Ekom order, calling the Consumer Loans API `/online/token/web`, and redirecting the customer to a configurable loan portal URL with the returned token.
- Adds provider settings, request/response DTOs, API client, events, and `PaymentSettings` extension.

## Notes
- The public docs page identifies the token endpoint but does not expose the actual production self-service portal redirect URL in a way I could verify, so `LoanPortalUrl` and `LoanPortalTokenQueryParameter` are intentionally configurable.
- I was not able to safely update `azure-pipelines.yml` through the connector because the file update was blocked by a safety check after the SHA refresh. The provider project has been generated, but the solution/pipeline wiring should be reviewed before merge.

## Review focus
- Confirm exact Consumer Loans v3 request field names against Teya/Borgun sandbox credentials.
- Confirm whether the merchant authentication is Basic auth, API key, or both for this merchant agreement.
- Confirm the correct loan portal URL and token query parameter.

## Sources reviewed
- Existing Straumur provider pattern in this repo.
- Teya/Borgun Consumer Loans API v3 documentation supplied in the task.