### PR TITLE
fix(paytrail): preserve decimal amounts

### DIFF
--- a/AspNetCore/EnsureTablesExist.cs
+++ b/AspNetCore/EnsureTablesExist.cs
@@ -35,6 +35,8 @@ class EnsureTablesExist
             db.Execute($"CREATE UNIQUE NONCLUSTERED INDEX [IX_EkomPaymentOrders_UniqueId] ON EkomPaymentOrders ( [UniqueId] ASC )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]");
         }
 
+        db.Execute("ALTER TABLE EkomPaymentOrders ALTER COLUMN Amount DECIMAL(18,2) NOT NULL");
+
         if (!dbSchema.Tables.Any(t => t.TableName == "EkomPayments"))
         {
             db.CreateTable<PaymentData>();

--- a/Core/Models/OrderStatus.cs
+++ b/Core/Models/OrderStatus.cs
@@ -37,7 +37,7 @@ public class OrderStatus
     /// <summary>
     /// Total amount
     /// </summary>
-    [Column, NotNull]
+    [Column(Precision = 18, Scale = 2), NotNull]
     public decimal Amount { get; set; }
 
     /// <summary>

--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailResponseController.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailResponseController.cs
@@ -81,7 +81,8 @@ public class PayTrailResponseController : ControllerBase
 
             if (callback.Status.Equals("ok", StringComparison.InvariantCultureIgnoreCase))
             {
-                var expectedAmount = Payment.ToMinorUnits(order.Amount, paymentSettings.Currency);
+                var expectedOrderAmount = GetExpectedOrderAmount(order, paymentSettings);
+                var expectedAmount = Payment.ToMinorUnits(expectedOrderAmount, paymentSettings.Currency);
                 if (callback.Amount != expectedAmount)
                 {
                     _logger.LogWarning("PayTrail Payment Response - Amount mismatch for order {OrderId}. Expected {ExpectedAmount}, got {ActualAmount}", orderId, expectedAmount, callback.Amount);
@@ -94,7 +95,7 @@ public class PayTrailResponseController : ControllerBase
 
                 if (!order.Paid)
                 {
-                    await SavePaymentDataAsync(order, callback, parameters).ConfigureAwait(false);
+                    await SavePaymentDataAsync(order, callback, parameters, expectedOrderAmount).ConfigureAwait(false);
 
                     order.Paid = true;
                     await _orderService.UpdateAsync(order).ConfigureAwait(false);
@@ -155,6 +156,15 @@ public class PayTrailResponseController : ControllerBase
         }
     }
 
+    static decimal GetExpectedOrderAmount(OrderStatus order, PaymentSettings paymentSettings)
+    {
+        var orderLines = paymentSettings.Orders?.ToList();
+
+        return orderLines is { Count: > 0 }
+            ? orderLines.Sum(x => x.GrandTotal)
+            : order.Amount;
+    }
+
     static PayTrailCallback? CreateCallback(IReadOnlyDictionary<string, string> parameters)
     {
         if (!parameters.TryGetValue("signature", out var signature)
@@ -179,7 +189,7 @@ public class PayTrailResponseController : ControllerBase
         };
     }
 
-    async Task SavePaymentDataAsync(OrderStatus order, PayTrailCallback callback, Dictionary<string, string> parameters)
+    async Task SavePaymentDataAsync(OrderStatus order, PayTrailCallback callback, Dictionary<string, string> parameters, decimal amount)
     {
         try
         {
@@ -195,7 +205,7 @@ public class PayTrailResponseController : ControllerBase
                     Status = callback.Status,
                     Parameters = parameters,
                 }),
-                Amount = order.Amount.ToString(),
+                Amount = amount.ToString(),
             };
 
             using var db = _dbFac.GetDatabase();


### PR DESCRIPTION
## Summary
- Validate Paytrail callbacks against the serialized payment order line total when available.
- Store Paytrail payment data using the resolved decimal amount instead of a rounded order amount.
- Preserve cents in `EkomPaymentOrders.Amount` by mapping and ensuring `DECIMAL(18,2)`.

## Test Plan
- Ran `dotnet build Ekom.Payments.sln`.
- Verify a EUR 12.98 Paytrail callback with `checkout-amount=1298` is accepted.
- Verify new `EkomPaymentOrders.Amount` rows keep two decimal places.
