### PR TITLE
fix(payments): handle duplicate and decimal responses

### DIFF
--- a/PaymentProviders/Ekom.Payments.Borgun/BorgunResponseController.cs
+++ b/PaymentProviders/Ekom.Payments.Borgun/BorgunResponseController.cs
@@ -39,11 +39,6 @@ public class BorgunResponseController : ControllerBase
         _dbFac = dbFac;
         _mailSvc = mailSvc;
     }
-    private string FormatPrice(decimal price)
-    {
-        return price.ToString(CultureInfo.InvariantCulture).Replace(".0","", StringComparison.InvariantCulture) + ",00";
-    }
-
     /// <summary>
     /// Receives a callback from Borgun when customer completes payment.
     /// Changes order status and optionally runs a custom callback provided by the application consuming this library.
@@ -95,7 +90,7 @@ public class BorgunResponseController : ControllerBase
             
             var currencyFormat = new CultureInfo(paymentSettings.Currency, false).NumberFormat;
 
-            var orderAmount = FormatPrice(order.Amount);
+            var orderAmount = Payment.FormatPrice(order.Amount, borgunSettings);
 
             var orderhashcheck = CryptoHelpers.GetHMACSHA256(borgunSettings.SecretCode,
                 new CheckHashMessage(borgunResponse.OrderId, orderAmount, paymentSettings.Currency).Message);

--- a/PaymentProviders/Ekom.Payments.Borgun/BorgunSettings.cs
+++ b/PaymentProviders/Ekom.Payments.Borgun/BorgunSettings.cs
@@ -30,5 +30,8 @@ public class BorgunSettings : PaymentSettingsBase<BorgunSettings>
 
     [EkomProperty(PropertyEditorType.Store)]
     public bool RequireCustomerInformation { get; set; }
+
+    public bool PreserveDecimalAmounts { get; set; }
+
     public string Language { get; set; }
 }

--- a/PaymentProviders/Ekom.Payments.Borgun/Payment.cs
+++ b/PaymentProviders/Ekom.Payments.Borgun/Payment.cs
@@ -43,8 +43,14 @@ class Payment : IPaymentProvider
         _config = config;
     }
 
-    private string FormatPrice(decimal price)
+    internal static string FormatPrice(decimal price, BorgunSettings borgunSettings)
     {
+        if (borgunSettings.PreserveDecimalAmounts)
+        {
+            var decimalAmount = Math.Round(price, 2, MidpointRounding.AwayFromZero);
+            return decimalAmount.ToString("0.00", CultureInfo.InvariantCulture).Replace('.', ',');
+        }
+
         var rounded = Math.Round(price, 0, MidpointRounding.AwayFromZero);
         return $"{rounded},00";
     }
@@ -98,7 +104,7 @@ class Payment : IPaymentProvider
                 { "returnurlcancel", paymentSettings.CancelUrl.ToString().AddQueryParam("paymentError","cancelPayment" ) },
                 { "returnurlerror", paymentSettings.ErrorUrl.ToString().AddQueryParam("paymentError","errorPayment" ) },
                 { "returnurlsuccessserver", reportUrl.ToString() },
-                { "amount", FormatPrice(total) },
+                { "amount", FormatPrice(total, borgunSettings) },
                 { "currency", paymentSettings.Currency },
                 { "language", paymentSettings.Language.ToUpper() == "IS-IS" ? "IS" : paymentSettings.Language.ToUpper() }
             };
@@ -109,8 +115,8 @@ class Payment : IPaymentProvider
 
                 formValues.Add("itemdescription_" + lineNumber, order.Title);
                 formValues.Add("itemcount_" + lineNumber, order.Quantity.ToString());
-                formValues.Add("itemunitamount_" + lineNumber, FormatPrice(order.Price));
-                formValues.Add("itemamount_" + lineNumber, FormatPrice(order.GrandTotal));
+                formValues.Add("itemunitamount_" + lineNumber, FormatPrice(order.Price, borgunSettings));
+                formValues.Add("itemamount_" + lineNumber, FormatPrice(order.GrandTotal, borgunSettings));
             }
 
             //if (borgunSettings.SkipReceipt)
@@ -163,7 +169,7 @@ class Payment : IPaymentProvider
                     paymentSettings.SuccessUrl.ToString(),
                     reportUrl.ToString(),
                     borgunOrderId,
-                    FormatPrice(total),
+                    FormatPrice(total, borgunSettings),
                     paymentSettings.Currency
                 ).Message
             );

--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailResponseController.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailResponseController.cs
@@ -93,13 +93,11 @@ public class PayTrailResponseController : ControllerBase
                     return BadRequest();
                 }
 
-                if (!order.Paid)
+                if (await TryMarkOrderPaidAsync(order).ConfigureAwait(false))
                 {
                     await SavePaymentDataAsync(order, callback, parameters, expectedOrderAmount).ConfigureAwait(false);
 
                     order.Paid = true;
-                    await _orderService.UpdateAsync(order).ConfigureAwait(false);
-
                     await Events.OnSuccessAsync(this, new SuccessEventArgs
                     {
                         OrderStatus = order,
@@ -163,6 +161,18 @@ public class PayTrailResponseController : ControllerBase
         return orderLines is { Count: > 0 }
             ? orderLines.Sum(x => x.GrandTotal)
             : order.Amount;
+    }
+
+    async Task<bool> TryMarkOrderPaidAsync(OrderStatus order)
+    {
+        using var db = _dbFac.GetDatabase();
+        var updatedRows = await db.OrderStatus
+            .Where(x => x.UniqueId == order.UniqueId && !x.Paid)
+            .Set(x => x.Paid, true)
+            .UpdateAsync()
+            .ConfigureAwait(false);
+
+        return updatedRows == 1;
     }
 
     static PayTrailCallback? CreateCallback(IReadOnlyDictionary<string, string> parameters)


### PR DESCRIPTION
## Summary
- Preserve decimal order amounts for Paytrail validation and storage while fixing existing rounded DB amount mismatches.
- Make Paytrail success processing idempotent so duplicate callbacks do not trigger payment completion twice.
- Keep Borgun amount rounding as the default and add `PreserveDecimalAmounts` as an opt-in setting.
- Use shared Borgun amount formatting for request and response hash validation.

## Test Plan
- Ran `dotnet build Ekom.Payments.sln`.
- Verify Paytrail EUR 12.98 callback with `checkout-amount=1298` validates successfully.
- Verify concurrent duplicate Paytrail success callbacks only fire success handling once.
- Verify default Borgun hash validation continues to use rounded amounts.
