### PR TITLE
fix(paytrail): calculate item VAT percentages

### DIFF
--- a/Core/Models/OrderItem.cs
+++ b/Core/Models/OrderItem.cs
@@ -16,6 +16,11 @@ public class OrderItem
     public decimal Price { get; set; }
 
     /// <summary>
+    /// 
+    /// </summary>
+    public decimal VAT { get; set; }
+    
+    /// <summary>
     /// Discount in percentages for <see cref="OrderItem"/>
     /// </summary>
     public int Discount { get; set; }

--- a/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
@@ -94,7 +94,7 @@ public class Payment : IPaymentProvider
                 {
                     UnitPrice = ToMinorUnits(lineItem.Price, paymentSettings.Currency),
                     Units = lineItem.Quantity,
-                    VatPercentage = 0,
+                    VatPercentage = CalculateVatPercentage(lineItem),
                     ProductCode = index.ToString(CultureInfo.InvariantCulture),
                     Description = lineItem.Title,
                 }).ToList(),
@@ -144,6 +144,23 @@ public class Payment : IPaymentProvider
         return currency.Equals("ISK", StringComparison.InvariantCultureIgnoreCase)
             || currency.Equals("JPY", StringComparison.InvariantCultureIgnoreCase)
             || currency.Equals("KRW", StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    internal static decimal CalculateVatPercentage(OrderItem lineItem)
+    {
+        if (lineItem.VAT <= 0)
+        {
+            return 0;
+        }
+
+        var netAmount = lineItem.GrandTotal - lineItem.VAT;
+
+        if (netAmount <= 0)
+        {
+            return 0;
+        }
+
+        return Math.Round(lineItem.VAT / netAmount * 100, 2, MidpointRounding.AwayFromZero);
     }
 
     static PaymentCustomer? CreateCustomer(CustomerInfo customerInfo)


### PR DESCRIPTION
## Summary
- Add VAT to order items so Paytrail item VAT can be derived from order line data.
- Calculate Paytrail `vatPercentage` per item from the line VAT amount and net line amount.
- Keep zero or invalid VAT inputs as `0` to avoid sending invalid percentages.

## Test Plan
- Ran `dotnet build "PaymentProviders/Ekom.Payments.PayTrail/Ekom.Payments.PayTrail.csproj"`.
- No tests run per request.
