### PR TITLE
fix(paytrail): round VAT percentages to tenths

### DIFF
--- a/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
@@ -160,7 +160,7 @@ public class Payment : IPaymentProvider
             return 0;
         }
 
-        return Math.Round(lineItem.VAT / netAmount * 100, 2, MidpointRounding.AwayFromZero);
+        return Math.Round(lineItem.VAT / netAmount * 100, 1, MidpointRounding.AwayFromZero);
     }
 
     static PaymentCustomer? CreateCustomer(CustomerInfo customerInfo)


### PR DESCRIPTION
## Summary
- Round calculated Paytrail item `vatPercentage` values to one decimal place.
- Satisfy Paytrail schema validation requiring VAT percentages to be divisible by `0.1`.

## Test Plan
- Ran `dotnet build "PaymentProviders/Ekom.Payments.PayTrail/Ekom.Payments.PayTrail.csproj"`.
- No tests run per request.
