### PR TITLE
fix(payments): support decimal order quantities

### DIFF
--- a/Core/Models/OrderItem.cs
+++ b/Core/Models/OrderItem.cs
@@ -23,7 +23,7 @@ public class OrderItem
     /// <summary>
     /// Discount in percentages for <see cref="OrderItem"/>
     /// </summary>
-    public int Discount { get; set; }
+    public decimal Discount { get; set; }
 
     /// <summary>
     /// 
@@ -33,5 +33,5 @@ public class OrderItem
     /// <summary>
     /// 
     /// </summary>
-    public int Quantity { get; set; }
+    public decimal Quantity { get; set; }
 }

--- a/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentRequest.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentRequest.cs
@@ -39,7 +39,7 @@ public class PaymentItem
     public int UnitPrice { get; set; }
 
     [JsonPropertyName("units")]
-    public int Units { get; set; }
+    public decimal Units { get; set; }
 
     [JsonPropertyName("vatPercentage")]
     public decimal VatPercentage { get; set; }

--- a/PaymentProviders/Ekom.Payments.Straumur/PaymentRequest.cs
+++ b/PaymentProviders/Ekom.Payments.Straumur/PaymentRequest.cs
@@ -45,7 +45,7 @@ public class Item
 
     public int Amount { get; set; }
 
-    public int Quantity { get; set; }
+    public decimal Quantity { get; set; }
 
     public int UnitPrice { get; set; }
 }


### PR DESCRIPTION
## Summary
- Change order item quantity and discount values to decimals so fractional order lines can be represented.
- Send decimal Paytrail item units to support fractional quantities in payment requests.
- Change Straumur payment request item quantity to decimal for consistency with order items.

## Test Plan
- Ran `dotnet build "PaymentProviders/Ekom.Payments.PayTrail/Ekom.Payments.PayTrail.csproj"`.
