### PR TITLE
fix(paytrail): align item totals with payment amount

### DIFF
--- a/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentRequest.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Models/CreatePaymentRequest.cs
@@ -11,7 +11,7 @@ public class CreatePaymentRequest
     public string Reference { get; set; } = string.Empty;
 
     [JsonPropertyName("amount")]
-    public int Amount { get; set; }
+    public decimal Amount { get; set; }
 
     [JsonPropertyName("currency")]
     public string Currency { get; set; } = string.Empty;

--- a/PaymentProviders/Ekom.Payments.PayTrail/PayTrailService.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/PayTrailService.cs
@@ -44,7 +44,13 @@ public class PayTrailService
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogError("PayTrail create payment failed. Status: {StatusCode} Body: {ResponseBody}", response.StatusCode, responseBody);
+            _logger.LogError(
+                "PayTrail create payment failed. Status: {StatusCode} Body: {ResponseBody} RequestUrl: {RequestUrl} RequestBody: {RequestBody} RequestHeaders: {@RequestHeaders}",
+                response.StatusCode,
+                responseBody,
+                httpRequest.RequestUri,
+                body,
+                CreateLogSafeHeaders(headers));
             response.EnsureSuccessStatusCode();
         }
 
@@ -56,5 +62,12 @@ public class PayTrailService
         }
 
         return createPaymentResponse;
+    }
+
+    static IDictionary<string, string> CreateLogSafeHeaders(IDictionary<string, string> headers)
+    {
+        return headers.ToDictionary(
+            x => x.Key,
+            x => x.Key.Equals("signature", StringComparison.InvariantCultureIgnoreCase) ? "[redacted]" : x.Value);
     }
 }

--- a/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
@@ -64,7 +64,9 @@ public class Payment : IPaymentProvider
             ArgumentException.ThrowIfNullOrEmpty(payTrailSettings.SecretKey);
             ArgumentNullException.ThrowIfNull(payTrailSettings.ApiBaseUrl);
 
-            var total = paymentSettings.Orders.Sum(x => x.GrandTotal);
+            var orderLines = paymentSettings.Orders.ToList();
+            var total = orderLines.Sum(x => x.GrandTotal);
+            var amountMinorUnits = ToMinorUnits(total, paymentSettings.Currency);
 
             var orderStatus = await _orderService.InsertAsync(
                 total,
@@ -74,10 +76,6 @@ public class Payment : IPaymentProvider
                 _httpCtx
             ).ConfigureAwait(false);
 
-            paymentSettings.SuccessUrl = PaymentsUriHelper.EnsureFullUri(paymentSettings.SuccessUrl, _httpCtx.Request);
-            paymentSettings.SuccessUrl = PaymentsUriHelper.AddQueryString(paymentSettings.SuccessUrl, "?reference=" + orderStatus.UniqueId);
-
-            var cancelUrl = PaymentsUriHelper.EnsureFullUri(paymentSettings.CancelUrl, _httpCtx.Request);
             var reportUrl = paymentSettings.ReportUrl == null
                 ? PaymentsUriHelper.EnsureFullUri(new Uri(reportPath, UriKind.Relative), _httpCtx.Request)
                 : PaymentsUriHelper.EnsureFullUri(paymentSettings.ReportUrl, _httpCtx.Request);
@@ -87,17 +85,10 @@ public class Payment : IPaymentProvider
             {
                 Stamp = orderStatus.UniqueId.ToString(),
                 Reference = !string.IsNullOrEmpty(paymentSettings.OrderNumber) ? paymentSettings.OrderNumber : orderStatus.ReferenceId.ToString(CultureInfo.InvariantCulture),
-                Amount = ToMinorUnits(total, paymentSettings.Currency),
+                Amount = amountMinorUnits,
                 Currency = paymentSettings.Currency,
                 Language = ParseSupportedLanguage(paymentSettings.Language),
-                Items = paymentSettings.Orders.Select((lineItem, index) => new PaymentItem
-                {
-                    UnitPrice = ToMinorUnits(lineItem.Price, paymentSettings.Currency),
-                    Units = lineItem.Quantity,
-                    VatPercentage = CalculateVatPercentage(lineItem),
-                    ProductCode = index.ToString(CultureInfo.InvariantCulture),
-                    Description = lineItem.Title,
-                }).ToList(),
+                Items = CreatePaymentItems(orderLines, paymentSettings.Currency, amountMinorUnits),
                 Customer = CreateCustomer(paymentSettings.CustomerInfo),
                 RedirectUrls = new PaymentUrls
                 {
@@ -110,6 +101,8 @@ public class Payment : IPaymentProvider
                     Cancel = callbackUrl.ToString(),
                 },
             };
+
+            LogPaymentItemAmountMismatch(paymentSettings, createPaymentRequest);
 
             var svc = new PayTrailService(_httpClientFactory, _logger);
             var response = await svc.CreatePaymentAsync(payTrailSettings, createPaymentRequest).ConfigureAwait(false);
@@ -163,6 +156,71 @@ public class Payment : IPaymentProvider
         return Math.Round(lineItem.VAT / netAmount * 100, 1, MidpointRounding.AwayFromZero);
     }
 
+    internal static List<PaymentItem> CreatePaymentItems(IReadOnlyList<OrderItem> orderLines, string currency, int amountMinorUnits)
+    {
+        var items = orderLines
+            .Select((lineItem, index) => CreatePaymentItem(lineItem, index, currency))
+            .ToList();
+
+        AdjustLastPaymentItemForTotalRounding(items, amountMinorUnits);
+
+        return items;
+    }
+
+    static PaymentItem CreatePaymentItem(OrderItem lineItem, int index, string currency)
+    {
+        var lineTotalMinorUnits = ToMinorUnits(lineItem.GrandTotal, currency);
+        var units = 1m;
+        var unitPriceMinorUnits = lineTotalMinorUnits;
+
+        if (lineItem.Quantity > 0)
+        {
+            var calculatedUnitPriceMinorUnits = lineTotalMinorUnits / lineItem.Quantity;
+
+            if (calculatedUnitPriceMinorUnits == Math.Truncate(calculatedUnitPriceMinorUnits))
+            {
+                units = lineItem.Quantity;
+                unitPriceMinorUnits = Convert.ToInt32(calculatedUnitPriceMinorUnits);
+            }
+        }
+
+        return new PaymentItem
+        {
+            UnitPrice = unitPriceMinorUnits,
+            Units = units,
+            VatPercentage = CalculateVatPercentage(lineItem),
+            ProductCode = index.ToString(CultureInfo.InvariantCulture),
+            Description = lineItem.Title,
+        };
+    }
+
+    static void AdjustLastPaymentItemForTotalRounding(List<PaymentItem> items, int amountMinorUnits)
+    {
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var itemsTotalMinorUnits = CalculateItemsTotalMinorUnits(items);
+        var differenceMinorUnits = amountMinorUnits - itemsTotalMinorUnits;
+
+        if (differenceMinorUnits == 0)
+        {
+            return;
+        }
+
+        var lastItem = items[^1];
+        var adjustedLineTotalMinorUnits = lastItem.UnitPrice * lastItem.Units + differenceMinorUnits;
+
+        lastItem.UnitPrice = Convert.ToInt32(adjustedLineTotalMinorUnits);
+        lastItem.Units = 1;
+    }
+
+    static decimal CalculateItemsTotalMinorUnits(IEnumerable<PaymentItem> items)
+    {
+        return items.Sum(x => x.UnitPrice * x.Units);
+    }
+
     static PaymentCustomer? CreateCustomer(CustomerInfo customerInfo)
     {
         if (customerInfo == null)
@@ -192,5 +250,52 @@ public class Payment : IPaymentProvider
             "EN" => "EN",
             _ => "EN",
         };
+    }
+
+    void LogPaymentItemAmountMismatch(PaymentSettings paymentSettings, CreatePaymentRequest request)
+    {
+        var items = request.Items.ToList();
+        var requestAmountMinorUnits = request.Amount;
+        var itemsTotalMinorUnits = CalculateItemsTotalMinorUnits(items);
+        var differenceMinorUnits = requestAmountMinorUnits - itemsTotalMinorUnits;
+
+        if (differenceMinorUnits == 0)
+        {
+            return;
+        }
+
+        var orderLines = paymentSettings.Orders?.ToList() ?? [];
+
+        _logger.LogWarning(
+            "PayTrail Payment Request - Amount mismatch before sending. Amount: {Amount} ItemsTotal: {ItemsTotal} Difference: {Difference} Currency: {Currency} OrderId: {OrderId} OrderNumber: {OrderNumber} OrderLines: {@OrderLines} PayTrailItems: {@PayTrailItems}",
+            requestAmountMinorUnits,
+            itemsTotalMinorUnits,
+            differenceMinorUnits,
+            paymentSettings.Currency,
+            paymentSettings.OrderUniqueId,
+            paymentSettings.OrderNumber,
+            orderLines.Select((lineItem, index) => new
+            {
+                Index = index,
+                lineItem.Title,
+                lineItem.Price,
+                lineItem.Quantity,
+                lineItem.GrandTotal,
+                lineItem.VAT,
+                lineItem.Discount,
+                ExpectedLineTotal = ToMinorUnits(lineItem.GrandTotal, paymentSettings.Currency),
+                SentUnitPrice = index < items.Count ? items[index].UnitPrice : 0,
+                SentLineTotal = index < items.Count ? items[index].UnitPrice * items[index].Units : 0,
+            }).ToList(),
+            items.Select((item, index) => new
+            {
+                Index = index,
+                item.Description,
+                item.ProductCode,
+                item.UnitPrice,
+                item.Units,
+                LineTotal = item.UnitPrice * item.Units,
+                item.VatPercentage,
+            }).ToList());
     }
 }

--- a/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
+++ b/PaymentProviders/Ekom.Payments.PayTrail/Payment.cs
@@ -66,7 +66,7 @@ public class Payment : IPaymentProvider
 
             var orderLines = paymentSettings.Orders.ToList();
             var total = orderLines.Sum(x => x.GrandTotal);
-            var amountMinorUnits = ToMinorUnits(total, paymentSettings.Currency);
+            decimal amountMinorUnits = ToMinorUnits(total, paymentSettings.Currency);
 
             var orderStatus = await _orderService.InsertAsync(
                 total,
@@ -156,7 +156,7 @@ public class Payment : IPaymentProvider
         return Math.Round(lineItem.VAT / netAmount * 100, 1, MidpointRounding.AwayFromZero);
     }
 
-    internal static List<PaymentItem> CreatePaymentItems(IReadOnlyList<OrderItem> orderLines, string currency, int amountMinorUnits)
+    internal static List<PaymentItem> CreatePaymentItems(IReadOnlyList<OrderItem> orderLines, string currency, decimal amountMinorUnits)
     {
         var items = orderLines
             .Select((lineItem, index) => CreatePaymentItem(lineItem, index, currency))
@@ -194,7 +194,7 @@ public class Payment : IPaymentProvider
         };
     }
 
-    static void AdjustLastPaymentItemForTotalRounding(List<PaymentItem> items, int amountMinorUnits)
+    static void AdjustLastPaymentItemForTotalRounding(List<PaymentItem> items, decimal amountMinorUnits)
     {
         if (items.Count == 0)
         {


### PR DESCRIPTION
## Summary
- Build Paytrail payment items from discounted line totals so item totals match the requested amount.
- Preserve quantities when the minor-unit unit price divides exactly; otherwise send the line total as a single unit to avoid rounding mismatches.
- Add diagnostics for Paytrail item total mismatches and include the serialized Paytrail request on API failures with the signature redacted.
- Avoid mutating `paymentSettings.SuccessUrl` while creating the Paytrail request.

## Test Plan
- Ran `dotnet build PaymentProviders/Ekom.Payments.PayTrail/Ekom.Payments.PayTrail.csproj`.
- Verify a Paytrail payment with discounted order lines no longer fails with `Sum of purchase item amounts does not match total amount.`
- Verify Paytrail error logs include request body and redacted request headers for troubleshooting.
