### PR TITLE
Feat/teya consumerloans

### DIFF
--- a/Core/IPaymentExecutionContext.cs
+++ b/Core/IPaymentExecutionContext.cs
@@ -1,0 +1,6 @@
+namespace Ekom.Payments;
+
+public interface IPaymentExecutionContext
+{
+    IDisposable EnsureContext();
+}

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/ApplicationBuilderExtensions.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/ApplicationBuilderExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Ekom.Payments.TeyaConsumerloans;
 
@@ -9,9 +11,29 @@ public static class ApplicationBuilderExtensions
 {
     public static IServiceCollection AddTeyaConsumerloans(this IServiceCollection services)
     {
-        services.AddSingleton<TeyaConsumerloansPollingService>();
-        services.AddHostedService(sp => sp.GetRequiredService<TeyaConsumerloansPollingService>());
+        services.TryAddSingleton<TeyaConsumerloansPollingService>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, TeyaConsumerloansHostedService>());
 
         return services;
+    }
+}
+
+class TeyaConsumerloansHostedService : IHostedService
+{
+    readonly TeyaConsumerloansPollingService _pollingService;
+
+    public TeyaConsumerloansHostedService(TeyaConsumerloansPollingService pollingService)
+    {
+        _pollingService = pollingService;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        return _pollingService.StartAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return _pollingService.StopAsync(cancellationToken);
     }
 }

--- a/PaymentProviders/Ekom.Payments.TeyaConsumerloans/TeyaConsumerloansPollingService.cs
+++ b/PaymentProviders/Ekom.Payments.TeyaConsumerloans/TeyaConsumerloansPollingService.cs
@@ -1,4 +1,3 @@
-using Ekom.Payments.Helpers;
 using Ekom.Payments.TeyaConsumerloans.Models;
 using LinqToDB;
 using Microsoft.AspNetCore.Http;
@@ -9,7 +8,6 @@ using Newtonsoft.Json;
 using System.Globalization;
 using System.Net.Mail;
 using System.Threading.Channels;
-using Umbraco.Cms.Core.Web;
 
 namespace Ekom.Payments.TeyaConsumerloans;
 
@@ -45,7 +43,7 @@ public class TeyaConsumerloansPollingService : BackgroundService
     readonly PaymentsConfiguration _settings;
     readonly IMailService _mailSvc;
     readonly IHttpContextAccessor _httpContextAccessor;
-    readonly IUmbracoContextFactory _umbracoContextFactory;
+    readonly IPaymentExecutionContext _paymentExecutionContext;
     readonly TeyaConsumerloansClient _client;
 
     public TeyaConsumerloansPollingService(
@@ -56,7 +54,7 @@ public class TeyaConsumerloansPollingService : BackgroundService
         PaymentsConfiguration settings,
         IMailService mailSvc,
         IHttpContextAccessor httpContextAccessor,
-        IUmbracoContextFactory umbracoContextFactory)
+        IPaymentExecutionContext paymentExecutionContext)
     {
         _logger = logger;
         _dbFac = dbFac;
@@ -64,7 +62,7 @@ public class TeyaConsumerloansPollingService : BackgroundService
         _settings = settings;
         _mailSvc = mailSvc;
         _httpContextAccessor = httpContextAccessor;
-        _umbracoContextFactory = umbracoContextFactory;
+        _paymentExecutionContext = paymentExecutionContext;
         _client = new TeyaConsumerloansClient(httpClientFactory, _logger);
     }
 
@@ -179,7 +177,7 @@ public class TeyaConsumerloansPollingService : BackgroundService
             order.Paid = true;
             await _orderService.UpdateAsync(order).ConfigureAwait(false);
 
-            using (var umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
+            using (_paymentExecutionContext.EnsureContext())
             {
                 await Events.OnSuccessAsync(this, new SuccessEventArgs
                 {
@@ -193,7 +191,7 @@ public class TeyaConsumerloansPollingService : BackgroundService
         {
             _logger.LogError(ex, "Teya Consumer Loans Response - Failed. OrderId: {OrderId}", order.UniqueId);
 
-            using var umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext();
+            using var paymentContext = _paymentExecutionContext.EnsureContext();
 
             await Events.OnErrorAsync(this, new ErrorEventArgs
             {

--- a/Umbraco/Ekom.Payments.U10/ApplicationBuilderExtensions.cs
+++ b/Umbraco/Ekom.Payments.U10/ApplicationBuilderExtensions.cs
@@ -14,6 +14,8 @@ static class ApplicationBuilderExtensions
         services.AddAspNetCoreEkomPayments(configuration);
 
         services.AddTransient<IUmbracoService, UmbracoService>();
+        services.AddSingleton<IPaymentExecutionContext, UmbracoPaymentExecutionContext>();
+        services.AddOptionalPaymentProviderServices();
 
         return services;
     }

--- a/Umbraco/Ekom.Payments.U10/OptionalPaymentProviderRegistration.cs
+++ b/Umbraco/Ekom.Payments.U10/OptionalPaymentProviderRegistration.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+
+namespace Ekom.Payments.Umb;
+
+static class OptionalPaymentProviderRegistration
+{
+    public static IServiceCollection AddOptionalPaymentProviderServices(this IServiceCollection services)
+    {
+        TryAddProvider(
+            services,
+            "Ekom.Payments.TeyaConsumerloans",
+            "Ekom.Payments.TeyaConsumerloans.ApplicationBuilderExtensions",
+            "AddTeyaConsumerloans");
+
+        return services;
+    }
+
+    static void TryAddProvider(
+        IServiceCollection services,
+        string assemblyName,
+        string extensionTypeName,
+        string methodName)
+    {
+        Assembly assembly;
+
+        try
+        {
+            assembly = Assembly.Load(assemblyName);
+        }
+        catch (FileNotFoundException)
+        {
+            return;
+        }
+        catch (FileLoadException)
+        {
+            return;
+        }
+        catch (BadImageFormatException)
+        {
+            return;
+        }
+
+        var extensionType = assembly.GetType(extensionTypeName, throwOnError: false);
+        var method = extensionType?.GetMethod(
+            methodName,
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(IServiceCollection) },
+            modifiers: null);
+
+        if (method == null)
+        {
+            return;
+        }
+
+        try
+        {
+            method.Invoke(null, new object[] { services });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            throw new InvalidOperationException($"Failed to register optional payment provider '{assemblyName}'.", ex.InnerException);
+        }
+    }
+}

--- a/Umbraco/Ekom.Payments.U10/OptionalPaymentProviderRegistration.cs
+++ b/Umbraco/Ekom.Payments.U10/OptionalPaymentProviderRegistration.cs
@@ -27,6 +27,25 @@ static class OptionalPaymentProviderRegistration
         try
         {
             assembly = Assembly.Load(assemblyName);
+
+            var extensionType = assembly.GetType(extensionTypeName, throwOnError: false);
+            var method = extensionType?.GetMethod(
+                methodName,
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(IServiceCollection) },
+                modifiers: null);
+
+            if (method == null)
+            {
+                return;
+            }
+
+            method.Invoke(null, new object[] { services });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            throw new InvalidOperationException($"Failed to register optional payment provider '{assemblyName}'.", ex.InnerException);
         }
         catch (FileNotFoundException)
         {
@@ -40,27 +59,17 @@ static class OptionalPaymentProviderRegistration
         {
             return;
         }
-
-        var extensionType = assembly.GetType(extensionTypeName, throwOnError: false);
-        var method = extensionType?.GetMethod(
-            methodName,
-            BindingFlags.Public | BindingFlags.Static,
-            binder: null,
-            types: new[] { typeof(IServiceCollection) },
-            modifiers: null);
-
-        if (method == null)
+        catch (ArgumentNullException)
         {
             return;
         }
-
-        try
+        catch (ArgumentException)
         {
-            method.Invoke(null, new object[] { services });
+            return;
         }
-        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        catch (Exception)
         {
-            throw new InvalidOperationException($"Failed to register optional payment provider '{assemblyName}'.", ex.InnerException);
+            return;
         }
     }
 }

--- a/Umbraco/Ekom.Payments.U10/Services/UmbracoPaymentExecutionContext.cs
+++ b/Umbraco/Ekom.Payments.U10/Services/UmbracoPaymentExecutionContext.cs
@@ -1,0 +1,18 @@
+using Umbraco.Cms.Core.Web;
+
+namespace Ekom.Payments.Umb;
+
+public class UmbracoPaymentExecutionContext : IPaymentExecutionContext
+{
+    readonly IUmbracoContextFactory _umbracoContextFactory;
+
+    public UmbracoPaymentExecutionContext(IUmbracoContextFactory umbracoContextFactory)
+    {
+        _umbracoContextFactory = umbracoContextFactory;
+    }
+
+    public IDisposable EnsureContext()
+    {
+        return _umbracoContextFactory.EnsureUmbracoContext();
+    }
+}

--- a/Umbraco/Ekom.Payments.U17/ApplicationBuilderExtensions.cs
+++ b/Umbraco/Ekom.Payments.U17/ApplicationBuilderExtensions.cs
@@ -14,6 +14,8 @@ static class ApplicationBuilderExtensions
         services.AddAspNetCoreEkomPayments(configuration);
 
         services.AddTransient<IUmbracoService, UmbracoService>();
+        services.AddSingleton<IPaymentExecutionContext, UmbracoPaymentExecutionContext>();
+        services.AddOptionalPaymentProviderServices();
 
         return services;
     }

--- a/Umbraco/Ekom.Payments.U17/OptionalPaymentProviderRegistration.cs
+++ b/Umbraco/Ekom.Payments.U17/OptionalPaymentProviderRegistration.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+
+namespace Ekom.Payments.Umb;
+
+static class OptionalPaymentProviderRegistration
+{
+    public static IServiceCollection AddOptionalPaymentProviderServices(this IServiceCollection services)
+    {
+        TryAddProvider(
+            services,
+            "Ekom.Payments.TeyaConsumerloans",
+            "Ekom.Payments.TeyaConsumerloans.ApplicationBuilderExtensions",
+            "AddTeyaConsumerloans");
+
+        return services;
+    }
+
+    static void TryAddProvider(
+        IServiceCollection services,
+        string assemblyName,
+        string extensionTypeName,
+        string methodName)
+    {
+        Assembly assembly;
+
+        try
+        {
+            assembly = Assembly.Load(assemblyName);
+        }
+        catch (FileNotFoundException)
+        {
+            return;
+        }
+        catch (FileLoadException)
+        {
+            return;
+        }
+        catch (BadImageFormatException)
+        {
+            return;
+        }
+
+        var extensionType = assembly.GetType(extensionTypeName, throwOnError: false);
+        var method = extensionType?.GetMethod(
+            methodName,
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(IServiceCollection) },
+            modifiers: null);
+
+        if (method == null)
+        {
+            return;
+        }
+
+        try
+        {
+            method.Invoke(null, new object[] { services });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            throw new InvalidOperationException($"Failed to register optional payment provider '{assemblyName}'.", ex.InnerException);
+        }
+    }
+}

--- a/Umbraco/Ekom.Payments.U17/OptionalPaymentProviderRegistration.cs
+++ b/Umbraco/Ekom.Payments.U17/OptionalPaymentProviderRegistration.cs
@@ -27,6 +27,25 @@ static class OptionalPaymentProviderRegistration
         try
         {
             assembly = Assembly.Load(assemblyName);
+
+            var extensionType = assembly.GetType(extensionTypeName, throwOnError: false);
+            var method = extensionType?.GetMethod(
+                methodName,
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(IServiceCollection) },
+                modifiers: null);
+
+            if (method == null)
+            {
+                return;
+            }
+
+            method.Invoke(null, new object[] { services });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            throw new InvalidOperationException($"Failed to register optional payment provider '{assemblyName}'.", ex.InnerException);
         }
         catch (FileNotFoundException)
         {
@@ -40,27 +59,17 @@ static class OptionalPaymentProviderRegistration
         {
             return;
         }
-
-        var extensionType = assembly.GetType(extensionTypeName, throwOnError: false);
-        var method = extensionType?.GetMethod(
-            methodName,
-            BindingFlags.Public | BindingFlags.Static,
-            binder: null,
-            types: new[] { typeof(IServiceCollection) },
-            modifiers: null);
-
-        if (method == null)
+        catch (ArgumentNullException)
         {
             return;
         }
-
-        try
+        catch (ArgumentException)
         {
-            method.Invoke(null, new object[] { services });
+            return;
         }
-        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        catch (Exception)
         {
-            throw new InvalidOperationException($"Failed to register optional payment provider '{assemblyName}'.", ex.InnerException);
+            return;
         }
     }
 }

--- a/Umbraco/Ekom.Payments.U17/Services/UmbracoPaymentExecutionContext.cs
+++ b/Umbraco/Ekom.Payments.U17/Services/UmbracoPaymentExecutionContext.cs
@@ -1,0 +1,18 @@
+using Umbraco.Cms.Core.Web;
+
+namespace Ekom.Payments.Umb;
+
+public class UmbracoPaymentExecutionContext : IPaymentExecutionContext
+{
+    readonly IUmbracoContextFactory _umbracoContextFactory;
+
+    public UmbracoPaymentExecutionContext(IUmbracoContextFactory umbracoContextFactory)
+    {
+        _umbracoContextFactory = umbracoContextFactory;
+    }
+
+    public IDisposable EnsureContext()
+    {
+        return _umbracoContextFactory.EnsureUmbracoContext();
+    }
+}


### PR DESCRIPTION
This update fixes the TeyaConsumerloans in two ways:

1. TeyaConsumerloansPollingService is now registered in U10 and U17 (optionally) so that the main project, using Ekom.Payments, doesn't have to register it. We don't want the "user" to have to know how these packages work. They should only have to add them to the project.
2. Since TeyaConsumerloansPollingService is a background service, we can have problems with the Umbraco context when it's success event calls a service, within the main project, that needs it. We fix this by making U10/U17 expose a class that ensures the umbraco context. TeyaConsumerloansPollingService can call that class and therefore doesn't need to know anything about the Umbraco version.